### PR TITLE
Fix of GetTempFileName Problem

### DIFF
--- a/ImageCompressor.Job/ImageCompressor.cs
+++ b/ImageCompressor.Job/ImageCompressor.cs
@@ -9,7 +9,7 @@ namespace ImageCompressor.Job {
         public event EventHandler<CompressionResult> Finished;
 
         public void CompressFile(string sourceFile) {
-            string targetFile = Path.ChangeExtension(Path.GetTempFileName(), Path.GetExtension(sourceFile));
+            string targetFile = Path.GetTempFileName();
 
             ProcessStartInfo start = new ProcessStartInfo("cmd") {
                 WindowStyle = ProcessWindowStyle.Hidden,


### PR DESCRIPTION
The original code creates everytime a new temp file, which is not deleted. There is an limit of 65536 temp files. After this count the GetTempFileName function throws an IOException.
