### PR TITLE
Force OptiPng to overwrite the temp file.

### DIFF
--- a/ImageCompressor.Job/Tools/png.cmd
+++ b/ImageCompressor.Job/Tools/png.cmd
@@ -1,2 +1,2 @@
-optipng %1 -out %2 -o3 -i0 -quiet
+optipng %1 -out %2 -o3 -i0 -quiet -clobber
 pngout %2 %2 /s1 /y /v /q


### PR DESCRIPTION
Without the clobber overload OptiPng wont overwrite the temp file so you will always return 0 for the length of `CompressionResult.ResultFileSize`. This causes you to always return the original file.
